### PR TITLE
adding support for custom filename

### DIFF
--- a/lua/compiler/languages/java.lua
+++ b/lua/compiler/languages/java.lua
@@ -21,11 +21,12 @@ M.options = {
 function M.action(selected_option)
   local utils = require("compiler.utils")
   local overseer = require("overseer")
-  local entry_point = utils.os_path(vim.fn.getcwd() .. "/Main.java")         -- working_directory/Main.java
-  local files = utils.find_files_to_compile(entry_point, "*.java")           -- *.java files under entry_point_dir (recursively)
-  local output_dir = utils.os_path(vim.fn.getcwd() .. "/bin/")               -- working_directory/bin/
-  local output = utils.os_path(vim.fn.getcwd() .. "/bin/Main")               -- working_directory/bin/Main.class
-  local output_filename = "Main"                                             -- working_directory/bin/Main
+  local working_directory = vim.api.nvim_exec(":echo '%:h'", true)           -- working_directory
+  local entry_point = vim.api.nvim_exec(":echo expand('%:p')", true)         -- working_directory/Main.java
+  local files = utils.find_files_to_compile(entry_point, "*.java")           -- *.java files under working_directory (recursively)
+  local output_filename = vim.api.nvim_exec(":echo expand('%:t:r')", true)   -- Main filename
+  local output = working_directory .. "/bin/" .. output_filename             -- working_directory/bin/Main.class
+  local output_dir = working_directory .. "/bin"                             -- working_directory/bin
   local arguments = "-Xlint:all"                                             -- arguments can be overriden in .solution
   local final_message = "--task finished--"
 

--- a/lua/compiler/languages/java.lua
+++ b/lua/compiler/languages/java.lua
@@ -21,10 +21,10 @@ M.options = {
 function M.action(selected_option)
   local utils = require("compiler.utils")
   local overseer = require("overseer")
-  local working_directory = vim.api.nvim_exec(":echo '%:h'", true)           -- working_directory
-  local entry_point = vim.api.nvim_exec(":echo expand('%:p')", true)         -- working_directory/Main.java
+  local working_directory = vim.fn.expand('%:h')                             -- working_directory
+  local entry_point = vim.fn.expand('%:p')                                   -- working_directory/Main.java
   local files = utils.find_files_to_compile(entry_point, "*.java")           -- *.java files under working_directory (recursively)
-  local output_filename = vim.api.nvim_exec(":echo expand('%:t:r')", true)   -- Main filename
+  local output_filename = vim.fn.expand('%:t:r')                             -- Main filename
   local output = working_directory .. "/bin/" .. output_filename             -- working_directory/bin/Main.class
   local output_dir = working_directory .. "/bin"                             -- working_directory/bin
   local arguments = "-Xlint:all"                                             -- arguments can be overriden in .solution


### PR DESCRIPTION
i added support for custom filenames, as you can easily without configuration run any java file anywhere, with any name you want. 
this works by changing the path from the cwd of the terminal running nvim, to the cwd of the buffer, as you already need to switch to the project directory. also, this is for ease of use, i know `solution.toml` works, but for easy running and testing, this is it.
Also only checked for class now, jar may need to look
this is just for java now, but you could look for every language. 

_PS: first pr, don't be so harsh_