### PR TITLE
Make default tasks (bootRun) also available to gradle

### DIFF
--- a/lua/compiler/utils-bau.lua
+++ b/lua/compiler/utils-bau.lua
@@ -141,7 +141,7 @@ local function get_gradle_opts(path)
 
     for line in file:lines() do
       -- Parse Kotlin DSL file
-      local task_match = line:match('tasks%.register%s*%(?%s*"(.-)"%s*%)?%s*{')
+      local task_match = line:match('tasks%.(%a+)%s*{') or line:match('tasks%.register%s*%(?%s*"(.-)"%s*%)?%s*{')
 
       if task_match then
         in_task = true

--- a/lua/compiler/utils-bau.lua
+++ b/lua/compiler/utils-bau.lua
@@ -148,6 +148,16 @@ local function isWindows()
   return os.getenv("OS") == "Windows_NT"
 end
 
+local function isTaskAlreadyAdded(options, task_name)
+  for _, option in ipairs(options) do
+    if option.value == task_name then
+      return true
+    end
+  end
+  return false
+end
+
+
 local function get_gradle_opts(path)
   local UNIX_COMMAND =
   "gradle tasks --all | awk '/Application tasks/,/^$/{if (!/^$/) print}' | awk 'NR > 2' | awk '!/--/ && NF {gsub(/ .*/, \"\", $0); print}' | sed '/^$/d'"
@@ -179,7 +189,6 @@ local function get_gradle_opts(path)
         { text = "Gradle " .. task_name, value = task_name, bau = "gradle" }
       )
     end
-    return options
   end
   local file = io.open(path, "r")
 
@@ -201,10 +210,12 @@ local function get_gradle_opts(path)
         in_task = true
         task_name = task_match
 
-        table.insert(
-          options,
-          { text = "Gradle " .. task_name, value = task_name, bau = "gradle" }
-        )
+        if not isTaskAlreadyAdded(options, task_name) then
+          table.insert(
+            options,
+            { text = "Gradle " .. task_name, value = task_name, bau = "gradle" }
+          )
+        end
       elseif in_task then
         local task_end = line:match("}")
         if task_end then
@@ -218,10 +229,12 @@ local function get_gradle_opts(path)
           in_task = true
           task_name = task_match
 
-          table.insert(
-            options,
-            { text = "Gradle " .. task_name, value = task_name, bau = "gradle" }
-          )
+          if not isTaskAlreadyAdded(options, task_name) then
+            table.insert(
+              options,
+              { text = "Gradle " .. task_name, value = task_name, bau = "gradle" }
+            )
+          end
         elseif in_task then
           local task_end = line:match("}")
           if task_end then

--- a/lua/compiler/utils-bau.lua
+++ b/lua/compiler/utils-bau.lua
@@ -162,7 +162,7 @@ local function get_gradle_opts(path)
   -- OS-specific commands to get all Application tasks from 'gradle tasks --all'
   -- Needs gradle to be install globally and available in the PATH
   -- For windows, powershell needs to be installed
-  local GRADLE_COMMAND = "gradle tasks --all"
+  local GRADLE_COMMAND = "gradle tasks"
   local RUN_POWERSHELL_COMMAND = "powershell -c"
   local POWERSHELL_COMMAND =
   [[ | Out-String | Select-String -Pattern "(?sm)Application tasks(.*?)(?:\r?\n){2}" | ForEach-Object { $_.Matches.Groups[1].Value -split "\r?\n" | ForEach-Object -Begin { $skip = $true } { if (-not $skip) { ($_ -split "\s+", 2)[0] } $skip = $false } | Where-Object { $_ -notmatch "--" -and $_.Trim() -ne "" } }]]

--- a/lua/compiler/utils-bau.lua
+++ b/lua/compiler/utils-bau.lua
@@ -145,15 +145,14 @@ local function parseTasks(output)
 end
 
 local function isWindows()
-  return os.getenv("OS") == "Windows_NT"
+  return os.getenv("OS") ~= "Windows_NT"
 end
 
 local function get_gradle_opts(path)
-  local GRADLE_COMMAND = "gradle tasks --all"
-  local WINDOWS_COMMAND = GRADLE_COMMAND ..
-      " | Select-String -Pattern 'Application tasks', '^$' -Context 0,10 | ForEach-Object { $_.Line } | Select-Object -Skip 2 | Where-Object { $_ -notmatch '--' -and $_.Trim() -ne '' }"
-  local UNIX_COMMAND = GRADLE_COMMAND ..
-      " | awk '/Application tasks/,/^$/{if (!/^$/) print}' | awk 'NR > 2' | awk '!/--/ && NF {gsub(/ .*/, \"\", $0); print}' | sed '/^$/d'"
+  local UNIX_COMMAND =
+  "gradle tasks --all | awk '/Application tasks/,/^$/{if (!/^$/) print}' | awk 'NR > 2' | awk '!/--/ && NF {gsub(/ .*/, \"\", $0); print}' | sed '/^$/d'"
+  local WINDOWS_COMMAND =
+  [[pwsh --Command 'gradle tasks --all | Out-String | Select-String -Pattern "(?sm)Application tasks(.*?)(?:\r?\n){2}" | ForEach-Object { $_.Matches.Groups[1].Value -split "\r?\n" | ForEach-Object -Begin { $skip = $true } { if (-not $skip) { ($_ -split "\s+", 2)[0] } $skip = $false } | Where-Object { $_ -notmatch "--" -and $_.Trim() -ne "" } }']]
 
   local options = {}
   local gradleOutput = ""

--- a/lua/compiler/utils-bau.lua
+++ b/lua/compiler/utils-bau.lua
@@ -132,11 +132,16 @@ end
 
 -- Function to parse tasks from the output
 local function parseTasks(output)
-  local tasks = {}
-  for task in output:gmatch("[^\r\n]+") do
-    table.insert(tasks, task)
+  -- Check if output is a single line and contains only characters
+  if output:find("[^\n\r]+") and not output:find("[^%a\n\r]") then
+    local tasks = {}
+    for task in output:gmatch("%S+") do
+      table.insert(tasks, task)
+    end
+    return tasks
+  else
+    return {}
   end
-  return tasks
 end
 
 -- Function to write tasks to a file
@@ -172,7 +177,7 @@ local function get_gradle_opts(path)
 
   if isWindows() then
     gradleOutput = executeCommand(WINDOWS_COMMAND)
-  else
+  else -- Assume Unix
     gradleOutput = executeCommand(UNIX_COMMAND)
   end
 

--- a/lua/compiler/utils-bau.lua
+++ b/lua/compiler/utils-bau.lua
@@ -144,22 +144,6 @@ local function parseTasks(output)
   end
 end
 
--- Function to write tasks to a file
-local function writeTasksToFile(filename, tasks)
-  local file = io.open(filename, "w")
-  if not file then
-    print("Error: Unable to open file for writing")
-    return
-  end
-
-  -- Write each task to the file
-  for _, task in ipairs(tasks) do
-    file:write(task .. "\n")
-  end
-
-  file:close() -- Close the file
-end
-
 local function isWindows()
   return os.getenv("OS") == "Windows_NT"
 end

--- a/lua/compiler/utils-bau.lua
+++ b/lua/compiler/utils-bau.lua
@@ -156,26 +156,27 @@ local function writeTasksToFile(filename, tasks)
 end
 
 local function isWindows()
-  return os.getenv("OS") ~= "Windows_NT"
+  return os.getenv("OS") == "Windows_NT"
 end
 
 local function get_gradle_opts(path)
-  local options = {}
+  local GRADLE_COMMAND = "gradle tasks --all"
+  local WINDOWS_COMMAND = GRADLE_COMMAND ..
+      " | Select-String -Pattern 'Application tasks', '^$' -Context 0,10 | ForEach-Object { $_.Line } | Select-Object -Skip 2 | Where-Object { $_ -notmatch '--' -and $_.Trim() -ne '' }"
+  local UNIX_COMMAND = GRADLE_COMMAND ..
+      " | awk '/Application tasks/,/^$/{if (!/^$/) print}' | awk 'NR > 2' | awk '!/--/ && NF {gsub(/ .*/, \"\", $0); print}' | sed '/^$/d'"
 
+  local options = {}
   local gradleOutput = ""
   local tasks = {}
 
   if isWindows() then
-    print("Gradle tasks parsing are not supported on Windows")
-    -- Context 0,10 is used to get up to 10 tasks that are under the "Application tasks" section
-    gradleOutput = executeCommand(
-      "gradle tasks --all | Select-String -Pattern 'Application tasks', '^$' -Context 0,10 | ForEach-Object { $_.Line } | Select-Object -Skip 2 | Where-Object { $_ -notmatch '--' -and $_.Trim() -ne '' }")
-    tasks = parseTasks(gradleOutput)
+    gradleOutput = executeCommand(WINDOWS_COMMAND)
   else
-    gradleOutput = executeCommand(
-      "gradle tasks --all | awk '/Application tasks/,/^$/{if (!/^$/) print}' | awk 'NR > 2' | awk '!/--/ && NF {gsub(/ .*/, \"\", $0); print}' | sed '/^$/d'")
-    tasks = parseTasks(gradleOutput)
+    gradleOutput = executeCommand(UNIX_COMMAND)
   end
+
+  tasks = parseTasks(gradleOutput)
 
   -- If the gradle command returns something, use it as the file content
   if tasks and #tasks > 0 then

--- a/lua/compiler/utils-bau.lua
+++ b/lua/compiler/utils-bau.lua
@@ -164,7 +164,6 @@ local function get_gradle_opts(path)
   -- For windows, powershell needs to be installed
   local GRADLE_COMMAND = "gradle tasks --all"
   local RUN_POWERSHELL_COMMAND = "powershell -c"
-  local RUN_POWERSHELL_COMMAND_UNIX = "pwsh -c" -- For testing on unix systems
   local POWERSHELL_COMMAND =
   [[ | Out-String | Select-String -Pattern "(?sm)Application tasks(.*?)(?:\r?\n){2}" | ForEach-Object { $_.Matches.Groups[1].Value -split "\r?\n" | ForEach-Object -Begin { $skip = $true } { if (-not $skip) { ($_ -split "\s+", 2)[0] } $skip = $false } | Where-Object { $_ -notmatch "--" -and $_.Trim() -ne "" } }]]
   local AWK_COMMAND =

--- a/lua/compiler/utils-bau.lua
+++ b/lua/compiler/utils-bau.lua
@@ -145,14 +145,14 @@ local function parseTasks(output)
 end
 
 local function isWindows()
-  return os.getenv("OS") ~= "Windows_NT"
+  return os.getenv("OS") == "Windows_NT"
 end
 
 local function get_gradle_opts(path)
   local UNIX_COMMAND =
   "gradle tasks --all | awk '/Application tasks/,/^$/{if (!/^$/) print}' | awk 'NR > 2' | awk '!/--/ && NF {gsub(/ .*/, \"\", $0); print}' | sed '/^$/d'"
   local WINDOWS_COMMAND =
-  [[pwsh --Command 'gradle tasks --all | Out-String | Select-String -Pattern "(?sm)Application tasks(.*?)(?:\r?\n){2}" | ForEach-Object { $_.Matches.Groups[1].Value -split "\r?\n" | ForEach-Object -Begin { $skip = $true } { if (-not $skip) { ($_ -split "\s+", 2)[0] } $skip = $false } | Where-Object { $_ -notmatch "--" -and $_.Trim() -ne "" } }']]
+  [[pwsh -c 'gradle tasks --all | Out-String | Select-String -Pattern "(?sm)Application tasks(.*?)(?:\r?\n){2}" | ForEach-Object { $_.Matches.Groups[1].Value -split "\r?\n" | ForEach-Object -Begin { $skip = $true } { if (-not $skip) { ($_ -split "\s+", 2)[0] } $skip = $false } | Where-Object { $_ -notmatch "--" -and $_.Trim() -ne "" } }']]
 
   local options = {}
   local gradleOutput = ""


### PR DESCRIPTION
With my Kotlin Spring Boot project, I wondered why gradle didn't show up in compiler.nvim, and turns out it just checks for registered task, while I was just using the default bootRun task, with no need for additional tasks, so I modified the task_match to also look for just tasks.

Hopefully this can help others with no specific gradle configs to get it working in Compiler.nvim without having to resort to create custom tasks.