### PR TITLE
refactor: use open_output component instead of OverseerOpen

### DIFF
--- a/lua/compiler/init.lua
+++ b/lua/compiler/init.lua
@@ -57,6 +57,11 @@ M.setup = function(opts)
       overseer.run_action(task, "dispose")
     end
   end, { desc = "Dispose all tasks running in the compiler" })
+
+  require("overseer").register_alias("compiler_subtask", {
+    "default",
+    { "open_output", on_start = true, on_complete = "never" },
+  })
 end
 
 return M

--- a/lua/compiler/languages/lua.lua
+++ b/lua/compiler/languages/lua.lua
@@ -22,24 +22,24 @@ function M.action(selected_option)
     local task = overseer.new_task({
       name = "- Lua interpreter",
       strategy = { "orchestrator",
-        tasks = {{ "shell", name = "- Run this file → " .. current_file,
+        tasks = {{ name = "- Run this file → " .. current_file,
           cmd =  "lua " .. current_file ..                                   -- run (interpreted)
                 " && echo " .. current_file ..                               -- echo
-                " && echo \"" .. final_message .. "\""
+                " && echo \"" .. final_message .. "\"",
+          components = { "compiler_subtask" }
         },},},})
     task:start()
-    vim.cmd("OverseerOpen")
   elseif selected_option == "option2" then
     local task = overseer.new_task({
       name = "- Lua interpreter",
       strategy = { "orchestrator",
-        tasks = {{ "shell", name = "- Run program → " .. entry_point,
+        tasks = {{ name = "- Run program → " .. entry_point,
             cmd = "lua " .. entry_point ..                                   -- run (interpreted)
                 " && echo " .. entry_point ..                                -- echo
-                " && echo \"" .. final_message .. "\""
+                " && echo \"" .. final_message .. "\"",
+            components = { "compiler_subtask" }
         },},},})
     task:start()
-    vim.cmd("OverseerOpen")
   elseif selected_option == "option3" then
     local entry_points
     local task = {}
@@ -55,10 +55,11 @@ function M.action(selected_option)
         if entry == "executables" then goto continue end
         entry_point = utils.os_path(variables.entry_point, true)
         arguments = variables.arguments or arguments -- optional
-        task = { "shell", name = "- Run program → " .. entry_point,
+        task = { name = "- Run program → " .. entry_point,
           cmd = "lua " .. arguments .. " " .. entry_point ..                 -- run (interpreted)
                 " && echo " .. entry_point ..                                -- echo
-                " && echo \"" .. final_message .. "\""
+                " && echo \"" .. final_message .. "\"",
+          components = { "compiler_subtask" }
         }
         table.insert(tasks, task) -- store all the tasks we've created
         ::continue::
@@ -68,10 +69,11 @@ function M.action(selected_option)
       if solution_executables then
         for entry, executable in pairs(solution_executables) do
           executable = utils.os_path(executable, true)
-          task = { "shell", name = "- Run program → " .. executable,
+          task = { name = "- Run program → " .. executable,
             cmd = executable ..                                              -- run
                   " && echo " .. executable ..                               -- echo
-                  " && echo \"" .. final_message .. "\""
+                  " && echo \"" .. final_message .. "\"",
+            components = { "compiler_subtask" }
           }
           table.insert(executables, task) -- store all the executables we've created
         end
@@ -84,17 +86,17 @@ function M.action(selected_option)
             executables   -- Then run the solution executable(s)
           }}})
       task:start()
-      vim.cmd("OverseerOpen")
 
     else -- If no .solution file
       -- Create a list of all entry point files in the working directory
       entry_points = utils.find_files(vim.fn.getcwd(), "main.lua")
       for _, entry_point in ipairs(entry_points) do
         entry_point = utils.os_path(entry_point, true)
-        task = { "shell", name = "- Run program → " .. entry_point,
+        task = { name = "- Run program → " .. entry_point,
           cmd = "lua " .. arguments .. " " .. entry_point ..                 -- run (interpreted)
                 " && echo " .. entry_point ..                                -- echo
-                " && echo \"" .. final_message .. "\""
+                " && echo \"" .. final_message .. "\"",
+          components = { "compiler_subtask" }
         }
         table.insert(tasks, task) -- store all the tasks we've created
       end
@@ -103,7 +105,6 @@ function M.action(selected_option)
         name = "- Lua interpreter", strategy = { "orchestrator", tasks = tasks }
       })
       task:start()
-      vim.cmd("OverseerOpen")
     end
   end
 


### PR DESCRIPTION
A demonstration of how the new `open_output` component can be used to fix #27. If you like this approach, these changes will need to be replicated across all the other supported languages.

I'm not sure how you want the code formatted. My stylua (v0.20.0) throws an error that `remove_trailing_separators` is an unknown field.