### PR TITLE
fix: parameter types for open_output component

### DIFF
--- a/lua/compiler/init.lua
+++ b/lua/compiler/init.lua
@@ -61,7 +61,7 @@ M.setup = function(opts)
   -- define the component used by the tasks
   require("overseer").register_alias("default_extended", {
     "default",
-    { "open_output", on_start = true, on_complete = "never" },
+    "open_output",
   })
 end
 


### PR DESCRIPTION
The type for on_start changed upstream, and the parameter defaults have been changed to not require any modifications for the use case here, so we can remove the customization of the parameters entirely.

fixes https://github.com/stevearc/overseer.nvim/issues/313