### PR TITLE
fix: manually set on_complete_dispose component on tasks

### DIFF
--- a/lua/compiler/init.lua
+++ b/lua/compiler/init.lua
@@ -60,6 +60,7 @@ M.setup = function(opts)
 
   -- define the component used by the tasks
   require("overseer").register_alias("default_extended", {
+    "on_complete_dispose",
     "default",
     "open_output",
   })


### PR DESCRIPTION
Related to https://github.com/stevearc/overseer.nvim/issues/315

I noticed that not all tasks that are created use the `default_extended` group that you defined; this will only work for the tasks that use it.