### PR TITLE
Add Windows support

### DIFF
--- a/lua/compiler/bau/cmake.lua
+++ b/lua/compiler/bau/cmake.lua
@@ -1,4 +1,5 @@
 --- CMakeLists.txt bau actions
+local utils = require "compiler.utils"
 
 local M = {}
 
@@ -6,6 +7,8 @@ local M = {}
 function M.action(option)
   local overseer = require("overseer")
   local final_message = "--task finished--"
+
+  local rm, mkdir, ignore_err = utils.get_commands()
 
   -- Global: CMAKE_BUILD_DIR
   local success, build_dir = pcall(vim.api.nvim_get_var, 'CMAKE_BUILD_DIR')
@@ -27,10 +30,10 @@ function M.action(option)
     name = "- CMake interpreter",
     strategy = { "orchestrator",
       tasks = {{ name = "- Run CMake → " .. option,
-        cmd = "mkdir -p \"" .. build_dir .. "\"" ..
+        cmd = mkdir .. "\"" .. build_dir .. "\" " .. ignore_err ..
               " && " .. cmd_build ..                                         -- Build to 'build' directory.
               " && " .. cmd_target ..                                        -- Build target from the 'build' directory.
-              " && echo '" .. cmd_build .. " && " .. cmd_target .. "'" ..    -- echo
+              " && echo \"" .. cmd_build .. " && " .. cmd_target .. "\"" ..    -- echo
               " && echo \"" .. final_message .. "\"",
         components = { "default_extended" }
       },},},})

--- a/lua/compiler/bau/meson.lua
+++ b/lua/compiler/bau/meson.lua
@@ -1,4 +1,5 @@
 --- meson.build bau actions
+local utils = require "compiler.utils"
 
 local M = {}
 
@@ -6,6 +7,8 @@ local M = {}
 function M.action(option)
   local overseer = require("overseer")
   local final_message = "--task finished--"
+
+  local rm, mkdir, ignore_err = utils.get_commands()
 
   -- Global: MESON_BUILD_DIR
   local success, build_dir = pcall(vim.api.nvim_get_var, 'MESON_BUILD_DIR')
@@ -29,7 +32,7 @@ function M.action(option)
     name = "- Meson interpreter",
     strategy = { "orchestrator",
       tasks = {{ name = "- Run Meson → " .. option,
-        cmd = "mkdir -p \"" .. build_dir .. "\"" ..
+        cmd = mkdir .. "\"" .. build_dir .. "\"" .. ignore_err ..
               " && " .. cmd_setup ..                                         -- Setup
               " && " .. cmd_build ..                                         -- Build target from the 'build' directory.
               --" && " .. cmd_target ..                                      -- Run target

--- a/lua/compiler/languages/c.lua
+++ b/lua/compiler/languages/c.lua
@@ -22,17 +22,19 @@ function M.action(selected_option)
   local final_message = "--task finished--"
 
 
+  local rm, mkdir, ignore_error = utils.get_commands()
+
   if selected_option == "option1" then
     local task = overseer.new_task({
       name = "- C compiler",
       strategy = { "orchestrator",
         tasks = {{ name = "- Build & run program → \"" .. entry_point .. "\"",
-          cmd = "rm -f \"" .. output .. "\" || true" ..                           -- clean
-              " && mkdir -p \"" .. output_dir .. "\"" ..                          -- mkdir
-              " && gcc " .. files .. " -o \"" .. output .. "\" " .. arguments ..  -- compile
-              " && \"" .. output .. "\"" ..                                       -- run
-              " && echo \"" .. entry_point .. "\"" ..                             -- echo
-              " && echo \"" .. final_message .. "\"",
+          cmd = rm .. "\"" .. output .. "\"" .. ignore_error ..                      -- clean
+                " && " .. mkdir .. "\"" .. output_dir .. "\"" .. ignore_error ..     -- mkdir
+                " && gcc " .. files .. " -o \"" .. output .. "\" " .. arguments ..   -- compile
+                " && \"" .. output .. "\"" ..                                        -- run
+                " && echo \"" .. entry_point .. "\"" ..                              -- echo
+                " && echo \"" .. final_message .. "\"",
           components = { "default_extended" }
         },},},})
     task:start()
@@ -41,11 +43,11 @@ function M.action(selected_option)
       name = "- C compiler",
       strategy = { "orchestrator",
         tasks = {{ name = "- Build program → \"" .. entry_point .. "\"",
-          cmd = "rm -f \"" .. output .. "\" || true" ..                           -- clean
-              " && mkdir -p \"" .. output_dir .. "\"" ..                          -- mkdir
-              " && gcc " .. files .. " -o \"" .. output .. "\" " .. arguments ..  -- compile
-              " && echo \"" .. entry_point .. "\"" ..                             -- echo
-              " && echo \"" .. final_message .. "\"",
+          cmd = rm .. "\"" .. output .. "\"" ..  ignore_error ..                    -- clean
+                " && " .. mkdir .. "\"" .. output_dir .. "\"" .. ignore_error ..    -- mkdir
+                " && gcc " .. files .. " -o \"" .. output .. "\" " .. arguments ..  -- compile
+                " && echo \"" .. entry_point .. "\"" ..                             -- echo
+                " && echo \"" .. final_message .. "\"",
           components = { "default_extended" }
         },},},})
     task:start()
@@ -78,13 +80,13 @@ function M.action(selected_option)
         output = utils.os_path(variables.output)
         output_dir = utils.os_path(output:match("^(.-[/\\])[^/\\]*$"))
         arguments = variables.arguments or arguments -- optional
+
         task = { name = "- Build program → \"" .. entry_point .. "\"",
-          cmd = "rm -f \"" .. output .. "\" || true" ..                           -- clean
-              " && mkdir -p \"" .. output_dir .. "\"" ..                          -- mkdir
-              " && gcc " .. files .. " -o \"" .. output .. "\" " .. arguments ..  -- compile
-              " && echo \"" .. entry_point .. "\"" ..                             -- echo
-              " && echo \"" .. final_message .. "\"",
-          components = { "default_extended" }
+          cmd = rm .. "\"" .. output .. "\"" ..  ignore_error ..                    -- clean
+                " && " .. mkdir .. "\"" .. output_dir .. "\"" .. ignore_error ..    -- mkdir
+                " && gcc " .. files .. " -o \"" .. output .. "\" " .. arguments ..  -- compile
+                " && echo \"" .. entry_point .. "\"" ..                             -- echo
+                " && echo \"" .. final_message .. "\""
         }
         table.insert(tasks, task) -- store all the tasks we've created
         ::continue::
@@ -121,12 +123,13 @@ function M.action(selected_option)
         files = utils.find_files_to_compile(entry_point, "*.c")
         output_dir = utils.os_path(entry_point:match("^(.-[/\\])[^/\\]*$") .. "bin")  -- entry_point/bin
         output = utils.os_path(output_dir .. "/program")                              -- entry_point/bin/program
+
         task = { name = "- Build program → \"" .. entry_point .. "\"",
-          cmd = "rm -f \"" .. output .. "\" || true" ..                          -- clean
-              " && mkdir -p \"" .. output_dir .. "\"" ..                         -- mkdir
-              " && gcc " .. files .. " -o \"" .. output .. "\" " .. arguments .. -- compile
-              " && echo \"" .. entry_point .. "\"" ..                            -- echo
-              " && echo \"" .. final_message .. "\"",
+          cmd = rm .. "\"" .. output .. "\"" ..  ignore_error ..                    -- clean
+                " && " .. mkdir .. "\"" .. output_dir .. "\"" .. ignore_error ..    -- mkdir
+                " && gcc " .. files .. " -o \"" .. output .. "\" " .. arguments ..  -- compile
+                " && echo \"" .. entry_point .. "\"" ..                             -- echo
+                " && echo \"" .. final_message .. "\"",
           components = { "default_extended" }
         }
         table.insert(tasks, task) -- store all the tasks we've created

--- a/lua/compiler/languages/cpp.lua
+++ b/lua/compiler/languages/cpp.lua
@@ -22,17 +22,19 @@ function M.action(selected_option)
   local final_message = "--task finished--"
 
 
+  local rm, mkdir, ignore_err = utils.get_commands()
+
   if selected_option == "option1" then
     local task = overseer.new_task({
       name = "- C++ compiler",
       strategy = { "orchestrator",
         tasks = {{ name = "- Build & run program → \"" .. entry_point .. "\"",
-          cmd = "rm -f \"" .. output .. "\" || true" ..                           -- clean
-              " && mkdir -p \"" .. output_dir .. "\"" ..                          -- mkdir
-              " && g++ " .. files .. " -o \"" .. output .. "\" " .. arguments ..  -- compile
-              " && \"" .. output .. "\"" ..                                       -- run
-              " && echo \"" .. entry_point .. "\"" ..                             -- echo
-              " && echo \"" .. final_message .. "\"",
+          cmd = rm .. "\"" .. output .. "\"" .. ignore_err ..                             -- clean
+                " && " .. mkdir  .. "\"" .. output_dir .. "\"" .. ignore_err ..           -- mkdir
+                " && g++ " .. files .. " -o \"" .. output .. "\" " .. arguments ..        -- compile
+                " && \"" .. output .. "\"" ..                                             -- run
+                " && echo \"" .. entry_point .. "\"" ..                                   -- echo
+                " && echo \"" .. final_message .. "\"",
           components = { "default_extended" }
         },},},})
     task:start()
@@ -41,11 +43,11 @@ function M.action(selected_option)
       name = "- C++ compiler",
       strategy = { "orchestrator",
         tasks = {{ name = "- Build program → \"" .. entry_point .. "\"",
-          cmd = "rm -f \"" .. output .. "\" || true" ..                           -- clean
-              " && mkdir -p \"" .. output_dir .. "\"" ..                          -- mkdir
-              " && g++ " .. files .. " -o \"" .. output .. "\" " .. arguments ..  -- compile
-              " && echo \"" .. entry_point .. "\"" ..                             -- echo
-              " && echo \"" .. final_message .. "\"",
+          cmd = rm .. "\"" .. output .. "\"" ..  ignore_err ..                     -- clean
+                " && " .. mkdir .. "\"" .. output_dir .. "\"" .. ignore_err ..     -- mkdir
+                " && g++ " .. files .. " -o \"" .. output .. "\" " .. arguments .. -- compile
+                " && echo \"" .. entry_point .. "\"" ..                            -- echo
+                " && echo \"" .. final_message .. "\"",
           components = { "default_extended" }
         },},},})
     task:start()
@@ -78,12 +80,13 @@ function M.action(selected_option)
         output = utils.os_path(variables.output)
         output_dir = utils.os_path(output:match("^(.-[/\\])[^/\\]*$"))
         arguments = variables.arguments or arguments -- optional
+
         task = { name = "- Build program → \"" .. entry_point .. "\"",
-          cmd = "rm -f \"" .. output .. "\" || true" ..                           -- clean
-              " && mkdir -p \"" .. output_dir .. "\"" ..                          -- mkdir
-              " && g++ " .. files .. " -o \"" .. output .. "\" " .. arguments ..  -- compile
-              " && echo \"" .. entry_point .. "\"" ..                             -- echo
-              " && echo \"" .. final_message .. "\"",
+          cmd = rm .. "\"" .. output .. "\"" ..  ignore_err ..                      -- clean
+                " && " .. mkdir .. "\"" .. output_dir .. "\"" .. ignore_err ..      -- mkdir
+                " && g++ " .. files .. " -o \"" .. output .. "\" " .. arguments ..  -- compile
+                " && echo \"" .. entry_point .. "\"" ..                             -- echo
+                " && echo \"" .. final_message .. "\"",
           components = { "default_extended" }
         }
         table.insert(tasks, task) -- store all the tasks we've created
@@ -121,12 +124,13 @@ function M.action(selected_option)
         files = utils.find_files_to_compile(entry_point, "*.cpp")
         output_dir = utils.os_path(entry_point:match("^(.-[/\\])[^/\\]*$") .. "bin")  -- entry_point/bin
         output = utils.os_path(output_dir .. "/program")                              -- entry_point/bin/program
+
         task = { name = "- Build program → \"" .. entry_point .. "\"",
-          cmd = "rm -f \"" .. output .. "\" || true" ..                          -- clean
-              " && mkdir -p \"" .. output_dir .. "\"" ..                         -- mkdir
-              " && g++ " .. files .. " -o \"" .. output .. "\" " .. arguments .. -- compile
-              " && echo \"" .. entry_point .. "\"" ..                            -- echo
-              " && echo \"" .. final_message .. "\"",
+          cmd = rm .. "\"" .. output .. "\"" ..  ignore_err ..                      -- clean
+                " && " .. mkdir .. "\"" .. output_dir .. "\"" .. ignore_err ..      -- mkdir
+                " && g++ " .. files .. " -o \"" .. output .. "\" " .. arguments ..  -- compile
+                " && echo \"" .. entry_point .. "\"" ..                             -- echo
+                " && echo \"" .. final_message .. "\"",
           components = { "default_extended" }
         }
         table.insert(tasks, task) -- store all the tasks we've created

--- a/lua/compiler/languages/cs.lua
+++ b/lua/compiler/languages/cs.lua
@@ -22,20 +22,22 @@ function M.action(selected_option)
   local files = utils.find_files_to_compile(entry_point, "*.cs")             -- *.cs files under entry_point_dir (recursively)
   local output_dir = utils.os_path(vim.fn.getcwd() .. "/bin/")               -- working_directory/bin/
   local output = utils.os_path(vim.fn.getcwd() .. "/bin/Program.exe")        -- working_directory/bin/program
-  local arguments = "-warn:4 /debug"                                         -- arguments can be overriden in .solution
+  local arguments = "-warn:4 /debug"                                        -- arguments can be overriden in .solution
   local final_message = "--task finished--"
+
+  local rm, mkdir, ignore_error = utils.get_commands()
 
   if selected_option == "option1" then
     local task = overseer.new_task({
       name = "- C# compiler",
       strategy = { "orchestrator",
         tasks = {{ name = "- Build & run program → \"" .. entry_point .. "\"",
-          cmd = "rm -f \"" .. output .. "\" || true" ..                            -- clean
-              " && mkdir -p \"" .. output_dir .. "\"" ..                           -- mkdir
-              " && csc " .. files .. " -out:\"" .. output .. "\" " .. arguments .. -- compile bytecode
-              " && mono \"" .. output .. "\"" ..                                   -- run
-              " ; echo \"" .. entry_point .. "\"" ..                               -- echo
-              " ; echo \"" .. final_message .. "\"",
+          cmd = rm .. "\"" .. output .. "\"" .. ignore_error ..                                   -- clean
+                " && " .. mkdir .. "\"" .. output_dir .. "\"" .. ignore_error ..                  -- mkdir
+                " && csc " .. files .. " -out:\"" .. output .. "\" " .. arguments ..  -- compile bytecode
+                " && mono \"" .. output .. "\"" ..                                          -- run
+                " && echo \"" .. entry_point .. "\"" ..                                      -- echo
+                " && echo \"" .. final_message .. "\"",
           components = { "default_extended" }
         },},},})
     task:start()
@@ -44,11 +46,11 @@ function M.action(selected_option)
       name = "- C# compiler",
       strategy = { "orchestrator",
         tasks = {{ name = "- Build program → \"" .. entry_point .. "\"",
-          cmd = "rm -f \"" .. output .. "\" || true" ..                            -- clean
-              " && mkdir -p \"" .. output_dir .. "\"" ..                           -- mkdir
-              " && csc " .. files .. " -out:\"" .. output .. "\" " .. arguments .. -- compile bytecode
-              " && echo \"" .. entry_point .. "\"" ..                              -- echo
-              " && echo \"" .. final_message .. "\"",
+          cmd = rm .. "\"" .. output .. "\"" .. ignore_error ..                        -- clean
+                " && " .. mkdir .. "\"" .. output_dir .. "\"" .. ignore_error ..       -- mkdir
+                " && csc " .. files .. " -out:\"" .. output .. "\" " .. arguments  ..  -- compile bytecode
+                " && echo \"" .. entry_point .. "\"" ..                                -- echo
+                " && echo \"" .. final_message .. "\"",
           components = { "default_extended" }
         },},},})
     task:start()
@@ -58,8 +60,8 @@ function M.action(selected_option)
       strategy = { "orchestrator",
         tasks = {{ name = "- Run program → \"" .. entry_point .. "\"",
           cmd = "mono \"" .. output .. "\"" ..                                     -- run
-                " ; echo \"" .. entry_point .. "\"" ..                             -- echo
-                " ; echo \"" .. final_message .. "\"",
+                " && echo \"" .. entry_point .. "\"" ..                            -- echo
+                " && echo \"" .. final_message .. "\"",
           components = { "default_extended" }
         },},},})
     task:start()
@@ -81,12 +83,13 @@ function M.action(selected_option)
         output = utils.os_path(variables.output)
         output_dir = utils.os_path(output:match("^(.-[/\\])[^/\\]*$"))
         arguments = variables.arguments or arguments -- optional
+
         task = { name = "- Build program → \"" .. entry_point .. "\"",
-          cmd = "rm -f \"" .. output .. "\" || true" ..                            -- clean
-              " && mkdir -p \"" .. output_dir .. "\"" ..                           -- mkdir
-              " && csc " .. files .. " -out:\"" .. output .. "\" " .. arguments .. -- compile bytecode
-              " && echo \"" .. entry_point .. "\"" ..                              -- echo
-              " && echo \"" .. final_message .. "\"",
+          cmd = rm .. "\"" .. output .. "\"" .. ignore_error ..                        -- clean
+                " && " .. mkdir .. "\"" .. output_dir .. "\"" .. ignore_error ..       -- mkdir
+                " && csc " .. files .. " -out:\"" .. output .. "\" " .. arguments  ..  -- compile bytecode
+                " && echo \"" .. entry_point .. "\"" ..                                -- echo
+                " && echo \"" .. final_message .. "\"",
           components = { "default_extended" }
         }
         table.insert(tasks, task) -- store all the tasks we've created
@@ -124,12 +127,13 @@ function M.action(selected_option)
         files = utils.find_files_to_compile(entry_point, "*.cs")
         output_dir = utils.os_path(entry_point:match("^(.-[/\\])[^/\\]*$") .. "bin")  -- entry_point/bin
         output = utils.os_path(output_dir .. "/program")                              -- entry_point/bin/program
+
         task = { name = "- Build program → \"" .. entry_point .. "\"",
-          cmd = "rm -f \"" .. output .. "\" || true" ..                            -- clean
-              " && mkdir -p \"" .. output_dir .. "\"" ..                           -- mkdir
-              " && csc " .. files .. " -out:\"" .. output .. "\" " .. arguments .. -- compile
-              " && echo \"" .. entry_point .. "\"" ..                              -- echo
-              " && echo \"" .. final_message .. "\"",
+          cmd = rm .. "\"" .. output .. "\"" .. ignore_error ..                                      -- clean
+                " && " .. mkdir .. "\"" .. output_dir .. "\"" .. ignore_error ..                     -- mkdir
+                " && csc " .. files .. " -out:\"" .. output .. "\" " .. arguments  ..    -- compile bytecode
+                " && echo \"" .. entry_point .. "\"" ..                                        -- echo
+                " && echo \"" .. final_message .. "\"",
           components = { "default_extended" }
         }
         table.insert(tasks, task) -- store all the tasks we've created

--- a/lua/compiler/languages/dart.lua
+++ b/lua/compiler/languages/dart.lua
@@ -29,9 +29,10 @@ function M.action(selected_option)
   local current_file = utils.os_path(vim.fn.expand('%:p'), true)                -- current file
   local entry_point = utils.os_path(vim.fn.getcwd() .. "/lib/main.dart", true)  -- working_directory/lib/main.dart
   local output_dir = utils.os_path(vim.fn.getcwd() .. "/bin/")                  -- working_directory/bin/
-  local output = utils.os_path(vim.fn.getcwd() .. "/bin/main")                  -- working_directory/bin/main
+  local output = utils.os_path(vim.fn.getcwd() .. "/bin/main", false, true)     -- working_directory/bin/main
   local final_message = "--task finished--"
 
+  local rm, mkdir, ignore_err = utils.get_commands()
 
   --=========================== INTERPRETED =================================--
   if selected_option == "option1" then
@@ -142,11 +143,11 @@ function M.action(selected_option)
       name = "- Dart compiler",
       strategy = { "orchestrator",
         tasks = {{ name = "- Build & run program → " .. entry_point,
-          cmd = "rm -f \"" .. output .. "\" || true" ..                            -- clean
-              " && mkdir -p \"" .. output_dir .. "\"" ..                           -- mkdir
+          cmd = rm .. "\"" .. output .. "\"" .. ignore_err ..                                       -- clean
+              " && ".. mkdir .. "\"" .. output_dir .. "\"" .. ignore_err ..                         -- mkdir
               " && dart compile exe " .. entry_point .. " -o \"" .. output .. "\" " .. arguments .. -- compile
-              " && \"" .. output .. "\"" ..                                        -- run
-              " && echo \"" .. entry_point .. "\"" ..                              -- echo
+              " && \"" .. output .. "\"" ..                                                         -- run
+              " && echo " .. entry_point ..                                                         -- echo
               " && echo \"" .. final_message .. "\"",
           components = { "default_extended" }
         },},},})
@@ -157,10 +158,10 @@ function M.action(selected_option)
       name = "- Dart compiler",
       strategy = { "orchestrator",
         tasks = {{ name = "- Build program → " .. entry_point,
-          cmd = "rm -f \"" .. output .. "\" || true" ..                            -- clean
-              " && mkdir -p \"" .. output_dir .. "\"" ..                           -- mkdir
+          cmd = rm .. "\"" .. output .. "\"" .. ignore_err ..                                       -- clean
+              " && ".. mkdir .. "\"" .. output_dir .. "\"" .. ignore_err ..                         -- mkdir
               " && dart compile exe " .. entry_point .. " -o \"" .. output .. "\" " .. arguments .. -- compile
-              " && echo \"" .. entry_point .. "\"" ..                              -- echo
+              " && echo " .. entry_point ..                                                         -- echo
               " && echo \"" .. final_message .. "\"",
           components = { "default_extended" }
         },},},})
@@ -171,8 +172,8 @@ function M.action(selected_option)
       name = "- Dart compiler",
       strategy = { "orchestrator",
         tasks = {{ name = "- Run program → \"" .. output .. "\"",
-          cmd = "\"" .. output .. "\"" ..                                          -- run
-                " && echo \"" .. entry_point .. "\"" ..                            -- echo
+          cmd = "\"" .. output .. "\"" ..                                -- run
+                " && echo " .. entry_point ..                            -- echo
                 " && echo \"" .. final_message .. "\"",
           components = { "default_extended" }
         },},},})
@@ -195,10 +196,10 @@ function M.action(selected_option)
         output_dir = utils.os_path(output:match("^(.-[/\\])[^/\\]*$"))
         local arguments = variables.arguments or "" -- optional
         task = { name = "- Run program → " .. entry_point,
-          cmd = "rm -f \"" .. output ..  "\" || true" ..                             -- clean
-                " && mkdir -p " .. output_dir ..                                     -- mkdir
+          cmd = rm .. "\"" .. output .. "\"" .. ignore_err ..                                         -- clean
+                " && ".. mkdir .. "\"" .. output_dir .. "\"" .. ignore_err ..                         -- mkdir
                 " && dart compile exe " .. entry_point .. " -o \"" .. output .. "\" " .. arguments .. -- compile
-                " && echo " .. entry_point ..                                        -- echo
+                " && echo " .. entry_point ..                                                         -- echo
                 " && echo \"" .. final_message .. "\"",
           components = { "default_extended" }
         }
@@ -237,8 +238,8 @@ function M.action(selected_option)
         output_dir = utils.os_path(entry_point:match("^(.-[/\\])[^/\\]*$") .. "../bin")                   -- entry_point/../bin
         output = utils.os_path(output_dir .. "/main")                                                     -- entry_point/bin/main
         task = { name = "- Build program → \"" .. entry_point .. "\"",
-          cmd ="rm -f \"" .. output ..  "\" || true" ..                                                   -- clean
-                " && mkdir -p \"" .. output_dir .. "\"" ..                                                -- mkdir
+          cmd = rm .. "\"" .. output .. "\"" .. ignore_err ..                                         -- clean
+                " && ".. mkdir .. "\"" .. output_dir .. "\"" .. ignore_err ..                         -- mkdir
                 " && dart compile exe \"" .. entry_point .. "\" -o \"" .. output .. "\" " .. arguments .. -- compile
                 " && echo \"" .. entry_point .. "\"" ..                                                   -- echo
                 " && echo \"" .. final_message .. "\"",

--- a/lua/compiler/languages/fortran.lua
+++ b/lua/compiler/languages/fortran.lua
@@ -16,20 +16,22 @@ function M.action(selected_option)
   local overseer = require("overseer")
   local current_file = utils.os_path(vim.fn.expand('%:p'), true)                           -- current file
   local output_dir = utils.os_path(vim.fn.stdpath("cache") .. "/compiler/fortran/")        -- working_directory/bin/
-  local output = output_dir .. "program"                                                   -- working_directory/bin/program
+  local output = utils.os_path(output_dir .. "program", true, true)                        -- working_directory/bin/program
   local arguments = ""                                                                     -- arguments can be overriden in .solution
   local final_message = "--task finished--"
+
+  local rm, mkdir, ignore_err = utils.get_commands()
 
   if selected_option == "option1" then
     local task = overseer.new_task({
       name = "- Fortran compiler",
       strategy = { "orchestrator",
         tasks = {{ name = "- Run this file → " .. current_file,
-          cmd = "rm -f \"" .. output ..  "\" || true" ..                                   -- clean
-                " && mkdir -p \"" .. output_dir .. "\"" ..                                 -- mkdir
+          cmd = rm .. output ..  ignore_err ..                                                 -- clean
+                " && " .. mkdir .. "\"" .. output_dir .. "\"" .. ignore_err ..                 -- mkdir
                 " && gfortran " .. current_file .. " -o \"" .. output .. "\" " .. arguments .. -- compile
-                " && " .. output ..                                                        -- run
-                " && echo " .. current_file ..                                             -- echo
+                " && " .. output ..                                                            -- run
+                " && echo " .. current_file ..                                                 -- echo
                 " && echo \"" .. final_message .. "\"",
           components = { "default_extended" }
         },},},})

--- a/lua/compiler/languages/go.lua
+++ b/lua/compiler/languages/go.lua
@@ -14,21 +14,22 @@ M.options = {
 function M.action(selected_option)
   local utils = require("compiler.utils")
   local overseer = require("overseer")
-  local entry_point = utils.os_path(vim.fn.getcwd() .. "/main.go", true)     -- working_directory/main.go
-  local files = utils.find_files_to_compile(entry_point, "*.go")             -- *.go files under entry_point_dir (recursively)
-  local output_dir = utils.os_path(vim.fn.getcwd() .. "/bin/", true)         -- working_directory/bin/
-  local output = utils.os_path(vim.fn.getcwd() .. "/bin/program", true)      -- working_directory/bin/program
-  local arguments = "-a -gcflags='-N -l'"                                    -- arguments can be overriden in .solution
+  local entry_point = utils.os_path(vim.fn.getcwd() .. "/main.go", true)      -- working_directory/main.go
+  local files = utils.find_files_to_compile(entry_point, "*.go")              -- *.go files under entry_point_dir (recursively)
+  local output_dir = utils.os_path(vim.fn.getcwd() .. "/bin/", true)          -- working_directory/bin/
+  local output = utils.os_path(vim.fn.getcwd() .. "/bin/program", true, true) -- working_directory/bin/program
+  local arguments = "-a -gcflags=\"-N -l\""                                   -- arguments can be overriden in .solution
   local final_message = "--task finished--"
 
+  local rm, mkdir, ignore_err = utils.get_commands()
 
   if selected_option == "option1" then
     local task = overseer.new_task({
       name = "- Go compiler",
       strategy = { "orchestrator",
         tasks = {{ name = "- Build & run program → " .. entry_point,
-          cmd = "rm -f " .. output ..                                                    -- clean
-                " && mkdir -p " .. output_dir ..                                         -- mkdir
+          cmd = rm .. output .. ignore_err ..                                            -- clean
+                " && " .. mkdir ..  output_dir .. ignore_err ..                          -- mkdir
                 " && go build " .. arguments .. " -o " .. output .. " " .. files ..      -- compile
                 " && " .. output ..                                                      -- run
                 " && echo " .. entry_point ..                                            -- echo
@@ -41,8 +42,8 @@ function M.action(selected_option)
       name = "- Go compiler",
       strategy = { "orchestrator",
         tasks = {{ name = "- Build program → " .. entry_point,
-          cmd = "rm -f " .. output ..                                                    -- clean
-                " && mkdir -p " .. output_dir ..                                         -- mkdir
+          cmd = rm .. output .. ignore_err ..                                            -- clean
+                " && " .. mkdir ..  output_dir .. ignore_err ..                          -- mkdir
                 " && go build " .. arguments .. " -o " .. output .. " " .. files ..      -- compile
                 " && echo " .. entry_point ..                                            -- echo
                 " && echo \"" .. final_message .. "\"",
@@ -74,15 +75,16 @@ function M.action(selected_option)
       for entry, variables in pairs(config) do
         if entry == "executables" then goto continue end
         entry_point = utils.os_path(variables.entry_point)
-        files = utils.find_files_to_compile(entry_point, "*.go")
-        output = utils.os_path(variables.output)
-        output_dir = utils.os_path(output:match("^(.-[/\\])[^/\\]*$"))
+        files = utils.find_files_to_compile(entry_point, "*.go", true)
+        entry_point = utils.os_path(variables.entry_point, true)
+        output = utils.os_path(variables.output, true, true)
+        output_dir = utils.os_path(output:match("^(.-[/\\])[^/\\]*$"), true)
         arguments = variables.arguments or arguments -- optional
-        task = { name = "- Build program → \"" .. entry_point .. "\"",
-          cmd = "rm -f \"" .. output .. "\"" ..                                          -- clean
-                " && mkdir -p \"" .. output_dir .. "\"" ..                               -- mkdir
-                " && go build " .. arguments .. " -o \"" .. output .. "\" " .. files ..  -- compile
-                " && echo \"" .. entry_point .. "\"" ..                                  -- echo
+        task = { name = "- Build program → " .. entry_point,
+          cmd = rm .. output .. ignore_err ..                                         -- clean
+                " && " .. mkdir ..  output_dir .. ignore_err ..                       -- mkdir
+                " && go build " .. arguments .. " -o " .. output .. " " ..  files ..  -- compile
+                " && echo " .. entry_point ..                                         -- echo
                 " && echo \"" .. final_message .. "\"",
           components = { "default_extended" }
         }
@@ -93,7 +95,7 @@ function M.action(selected_option)
       local solution_executables = config["executables"]
       if solution_executables then
         for entry, executable in pairs(solution_executables) do
-          executable = utils.os_path(executable, true)
+          executable = utils.os_path(executable, true, true)
           task = { name = "- Run program → " .. executable,
             cmd = executable ..                                                          -- run
                   " && echo " .. executable ..                                           -- echo
@@ -119,13 +121,14 @@ function M.action(selected_option)
       for _, entry_point in ipairs(entry_points) do
         entry_point = utils.os_path(entry_point)
         files = utils.find_files_to_compile(entry_point, "*.go")
-        output_dir = utils.os_path(entry_point:match("^(.-[/\\])[^/\\]*$") .. "bin")     -- entry_point/bin
-        output = utils.os_path(output_dir .. "/program")                                 -- entry_point/bin/program
-        task = { name = "- Build program → \"" .. entry_point .. "\"",
-          cmd = "rm -f \"" .. output .. "\"" ..                                          -- clean
-                " && mkdir -p \"" .. output_dir .. "\"" ..                               -- mkdir
-                " && go build " .. arguments .. " -o \"" .. output .. "\" " .. files ..  -- compile
-                " && echo \"" .. entry_point .. "\"" ..                                  -- echo
+        entry_point = utils.os_path(entry_point,true)
+        output_dir = utils.os_path(entry_point:match("^(.-[/\\])[^/\\]*$") .. "bin", true)     -- entry_point/bin
+        output = utils.os_path(output_dir .. "/program", true, true)                           -- entry_point/bin/program
+        task = { name = "- Build program → " .. entry_point,
+          cmd = rm .. output .. ignore_err ..                                        -- clean
+                " && " .. mkdir ..  output_dir .. ignore_err ..                      -- mkdir
+                " && go build " .. arguments .. " -o " .. output .. " " .. files ..  -- compile
+                " && echo " .. entry_point ..                                        -- echo
                 " && echo \"" .. final_message .. "\"",
           components = { "default_extended" }
         }

--- a/lua/compiler/languages/java.lua
+++ b/lua/compiler/languages/java.lua
@@ -21,13 +21,20 @@ M.options = {
 function M.action(selected_option)
   local utils = require("compiler.utils")
   local overseer = require("overseer")
-  local entry_point = utils.os_path(vim.fn.getcwd() .. "/Main.java")         -- working_directory/Main.java
-  local files = utils.find_files_to_compile(entry_point, "*.java")           -- *.java files under entry_point_dir (recursively)
-  local output_dir = utils.os_path(vim.fn.getcwd() .. "/bin/")               -- working_directory/bin/
-  local output = utils.os_path(vim.fn.getcwd() .. "/bin/Main")               -- working_directory/bin/Main.class
-  local output_filename = "Main"                                             -- working_directory/bin/Main
-  local arguments = "-Xlint:all"                                             -- arguments can be overriden in .solution
+  local entry_point = utils.os_path(vim.fn.getcwd() .. "/Main.java")   -- working_directory/Main.java
+  local files = utils.find_files_to_compile(entry_point, "*.java")     -- *.java files under entry_point_dir (recursively)
+  local output_dir = utils.os_path(vim.fn.getcwd() .. "/bin/")         -- working_directory/bin/
+  local output = utils.os_path(vim.fn.getcwd() .. "/bin/Main")         -- working_directory/bin/Main.class
+  local output_filename = "Main"                                       -- working_directory/bin/Main
+  local arguments = "-Xlint:all"                                       -- arguments can be overriden in .solution
   local final_message = "--task finished--"
+
+  -- HACK: I don't know why, but javac has problems backslashes '\' as path seperators, so we convert to '/'
+  output_dir = output_dir:gsub("\\", "/")
+  output = output:gsub("\\", "/")
+  files = files:gsub("\\", "/")
+
+  local rm_file, mkdir, ignore_err = utils.get_commands()
 
   --========================== Build as class ===============================--
   if selected_option == "option1" then
@@ -35,8 +42,8 @@ function M.action(selected_option)
       name = "- Java compiler",
       strategy = { "orchestrator",
         tasks = {{ name = "- Build & run program (class) → \"" .. entry_point .. "\"",
-          cmd = "rm -f \"" .. output_dir .. "*.class\"" .. " || true" ..                   -- clean
-                " && mkdir -p \"" .. output_dir .. "\"" ..                                 -- mkdir
+          cmd = rm_file .. "\"" .. output_dir .. "*.class\"" .. ignore_err ..               -- clean
+                " && " .. mkdir .. "\"" .. output_dir .. "\"" .. ignore_err ..             -- mkdir
                 " && javac -d \"" .. output_dir .. "\" " .. arguments .. " " .. files ..   -- compile bytecode (.class)
                 " && java -cp \"" .. output_dir .. "\" " .. output_filename ..             -- run
                 " && echo \"" .. entry_point .. "\"" ..                                    -- echo
@@ -49,8 +56,8 @@ function M.action(selected_option)
       name = "- Java compiler",
       strategy = { "orchestrator",
         tasks = {{ name = "- Build program (class) → \"" .. entry_point .. "\"",
-          cmd = "rm -f \"" .. output_dir .. "/*.class\"" .. " || true" ..                  -- clean
-                " && mkdir -p \"" .. output_dir .. "\"" ..                                 -- mkdir
+          cmd = rm_file .. "\"" .. output_dir .. "*.class\"" .. ignore_err ..             -- clean
+                " && " .. mkdir .. "\"" .. output_dir .. "\"" .. ignore_err ..             -- mkdir
                 " && javac -d \"" .. output_dir .. "\" " .. arguments .. " "  .. files ..  -- compile bytecode (.class)
                 " && echo \"" .. entry_point .. "\"" ..                                    -- echo
                 " && echo \"" .. final_message .. "\"",
@@ -83,12 +90,14 @@ function M.action(selected_option)
         if entry == "executables" then goto continue end
         entry_point = utils.os_path(variables.entry_point)
         files = utils.find_files_to_compile(entry_point, "*.java")
+        files = files:gsub("\\", "/")
         output = utils.os_path(variables.output)
         output_dir = utils.os_path(output:match("^(.-[/\\])[^/\\]*$"))
+        output_dir = output_dir:gsub("\\", "/")
         arguments = variables.arguments or arguments -- optiona
         task = { name = "- Build program (class) → \"" .. entry_point .. "\"",
-          cmd = "rm -f \"" .. output_dir .. "/*.class\"" .. " || true" ..                  -- clean
-                " && mkdir -p \"" .. output_dir .. "\"" ..                                 -- mkdir
+          cmd = rm_file .. "\"" .. output_dir .. "*.class\"" .. ignore_err ..                  -- clean
+                " && " .. mkdir .. "\"" .. output_dir .. "\"" .. ignore_err ..             -- mkdir
                 " && javac -d \"" .. output_dir .. "\" " .. arguments .. " "  .. files ..  -- compile bytecode
                 " && echo \"" .. entry_point .. "\""  ..                                   -- echo
                 " && echo \"" .. final_message .. "\"",
@@ -102,6 +111,7 @@ function M.action(selected_option)
       if solution_executables then
         for entry, executable in pairs(solution_executables) do
           output_dir = utils.os_path(executable:match("^(.-[/\\])[^/\\]*$"))
+          output_dir = output_dir:gsub("\\", "/")
           output_filename = vim.fn.fnamemodify(executable, ':t:r')
           task = { name = "- Run program (class) → \"" .. executable .. "\"",
             cmd = "java -cp \"" .. output_dir .. "\" " .. output_filename ..               -- run
@@ -128,10 +138,12 @@ function M.action(selected_option)
       for _, entry_point in ipairs(entry_points) do
         entry_point = utils.os_path(entry_point)
         files = utils.find_files_to_compile(entry_point, "*.java")
+        files = files:gsub("\\", "/")
         output_dir = utils.os_path(entry_point:match("^(.-[/\\])[^/\\]*$") .. "bin")       -- entry_point/bin
+        output_dir = output_dir:gsub("\\", "/")
         task = { name = "- Build program (class) → \"" .. entry_point .. "\"",
-          cmd = "rm -f \"" .. output_dir .. "/*.class\"" .. " || true" ..                  -- clean
-                " && mkdir -p \"" .. output_dir .."\"" ..                                  -- mkdir
+          cmd = rm_file .. "\"" .. output_dir .. "*.class\"" .. ignore_err ..                  -- clean
+                " && " .. mkdir .. "\"" .. output_dir .."\"" .. ignore_err ..              -- mkdir
                 " && javac -d \"" .. output_dir .. "\" " .. arguments .. " "  .. files ..  -- compile bytecode
                 " && echo \"" .. entry_point .. "\"" ..                                    -- echo
                 " && echo \"" .. final_message .. "\"",
@@ -159,8 +171,8 @@ function M.action(selected_option)
       name = "- Java compiler",
       strategy = { "orchestrator",
         tasks = {{ name = "- Build & run program (jar) → \"" .. entry_point .. "\"",
-          cmd = "rm -f \"" .. output .. ".jar\"" .. " || true" ..                                           -- clean
-                " && mkdir -p \"" .. output_dir .. "\"" ..                                                  -- mkdir
+          cmd = rm_file .. "\"" .. output .. ".jar\"" .. ignore_err ..                                      -- clean
+                " && " .. mkdir .. "\"" .. output_dir .. "\"" .. ignore_err ..                              -- mkdir
                 " && jar cfe \"" .. output .. ".jar\" " .. output_filename .. " -C \"" .. output_dir .. "\" . " ..  -- compile bytecode (.jar)
                 " && java -jar \"" .. output .. ".jar\"" ..                                                 -- run
                 " && echo \"" .. entry_point .. "\"" ..                                                     -- echo
@@ -173,8 +185,8 @@ function M.action(selected_option)
       name = "- Java compiler",
       strategy = { "orchestrator",
         tasks = {{ name = "- Build program (jar) → \"" .. entry_point .. "\"",
-          cmd = "rm -f \"" .. output .. ".jar\"" .. " || true" ..                                           -- clean
-                " && mkdir -p \"" .. output_dir .. "\"" ..                                                  -- mkdir
+          cmd = rm_file .. "\"" .. output .. ".jar\"" .. ignore_err ..                                      -- clean
+                " && " .. mkdir .. "\"" .. output_dir .. "\"" .. ignore_err ..                              -- mkdir
                 " && jar cfe \"" .. output .. ".jar\" " .. output_filename .. " -C \"" .. output_dir .. "\" . " ..  -- compile bytecode (.jar)
                 " && echo \"" .. entry_point .. "\"" ..                                                     -- echo
                 " && echo \"" .. final_message .. "\"",
@@ -206,16 +218,20 @@ function M.action(selected_option)
       for entry, variables in pairs(config) do
         if entry == "executables" then goto continue end
         entry_point = utils.os_path(variables.entry_point)
+        entry_point = entry_point:gsub("\\", "/")
         files = utils.find_files_to_compile(entry_point, "*.java")
+        files = files:gsub("\\", "/")
         output = utils.os_path(variables.output)
+        output = output:gsub("\\", "/")
         output_dir = utils.os_path(output:match("^(.-[/\\])[^/\\]*$"))
+        output_dir = output_dir:gsub("\\", "/")
         output_filename = vim.fn.fnamemodify(output, ':t:r')
         arguments = variables.arguments or arguments -- optional
         task = { name = "- Build program (jar) → \"" .. entry_point .. "\"",
-          cmd = "rm -f \"" .. output .. "\" || true" ..                                                     -- clean
-                " && mkdir -p \"" .. output_dir .. "\"" ..                                                  -- mkdir
+          cmd = rm_file .. "\"" .. output .. "\"" .. ignore_err ..                                                   -- clean
+                " && " .. mkdir .. "\"" .. output_dir .. "\"" .. ignore_err ..                                  -- mkdir
                 " && jar cfe \"" .. output .. "\" " .. output_filename .. " -C \"" .. output_dir .. "\" . " ..  -- compile bytecode (jar)
-                " && echo \"" .. entry_point .. "\"" ..                                                     -- echo
+                " && echo \"" .. entry_point .. "\"" ..                                                         -- echo
                 " && echo \"" .. final_message .. "\"",
           components = { "default_extended" }
         }
@@ -254,10 +270,10 @@ function M.action(selected_option)
         output_dir = utils.os_path(entry_point:match("^(.-[/\\])[^/\\]*$") .. "bin")                            -- entry_point/bin
         output = utils.os_path(output_dir .. "/Main")                                                           -- entry_point/bin/Main.jar
         task = { name = "- Build program (jar) → \"" .. entry_point .. "\"",
-          cmd = "rm -f \"" .. output .. ".jar\" " .. " || true" ..                                              -- clean
-                " && mkdir -p \"" .. output_dir .. "\"" ..                                                      -- mkdir
+          cmd = rm_file .. "\"" .. output .. ".jar\" " .. ignore_err ..                                             -- clean
+                " && " .. mkdir .. "\"" .. output_dir .. "\"" .. ignore_err ..                                      -- mkdir
                 " && jar cfe \"" .. output .. ".jar\" " .. output_filename .. " -C \"" .. output_dir .. "\" . " ..  -- compile bytecode (jar)
-                " && echo \"" .. entry_point .. "\"" ..                                                         -- echo
+                " && echo \"" .. entry_point .. "\"" ..                                                             -- echo
                 " && echo \"" .. final_message .. "\"",
           components = { "default_extended" }
         }

--- a/lua/compiler/languages/rust.lua
+++ b/lua/compiler/languages/rust.lua
@@ -21,19 +21,21 @@ M.options = {
 function M.action(selected_option)
   local utils = require("compiler.utils")
   local overseer = require("overseer")
-  local entry_point = utils.os_path(vim.fn.getcwd() .. "/main.rs", true)     -- working_directory/main.rs
-  local output_dir = utils.os_path(vim.fn.getcwd() .. "/bin/", true)         -- working_directory/bin/
-  local output = utils.os_path(vim.fn.getcwd() .. "/bin/program", true)      -- working_directory/bin/program
-  local arguments = "-D warnings -g"                                         -- arguments can be overriden in .solution
+  local entry_point = utils.os_path(vim.fn.getcwd() .. "/main.rs", true)      -- working_directory/main.rs
+  local output_dir = utils.os_path(vim.fn.getcwd() .. "/bin/", true)          -- working_directory/bin/
+  local output = utils.os_path(vim.fn.getcwd() .. "/bin/program", true, true) -- working_directory/bin/program
+  local arguments = "-D warnings -g"                                          -- arguments can be overriden in .solution
   local final_message = "--task finished--"
+
+  local rm, mkdir, ignore_err = utils.get_commands()
 
   if selected_option == "option1" then
     local task = overseer.new_task({
       name = "- Rust compiler",
       strategy = { "orchestrator",
         tasks = {{ name = "- Build & run program → " .. entry_point,
-          cmd = "rm -f " .. output ..  " || true" ..                                    -- clean
-                " && mkdir -p " .. output_dir ..                                        -- mkdir
+          cmd = rm .. output .. ignore_err ..                                           -- clean
+                " && " .. mkdir .. output_dir .. ignore_err ..                          -- mkdir
                 " && rustc " .. entry_point .. " -o " .. output .. " " .. arguments ..  -- compile
                 " && " .. output ..                                                     -- run
                 " && echo " .. entry_point ..                                           -- echo
@@ -46,8 +48,8 @@ function M.action(selected_option)
       name = "- Rust compiler",
       strategy = { "orchestrator",
         tasks = {{ name = "- Build program → " .. entry_point,
-          cmd = "rm -f " .. output ..  " || true" ..                                    -- clean
-                " && mkdir -p " .. output_dir ..                                        -- mkdir
+          cmd = rm .. output .. ignore_err ..                                           -- clean
+                " && " .. mkdir .. output_dir .. ignore_err ..                          -- mkdir
                 " && rustc " .. entry_point .. " -o " .. output .. " " .. arguments ..  -- compile
                 " && echo " .. entry_point ..                                           -- echo
                 " && echo \"" .. final_message .. "\"",
@@ -79,12 +81,12 @@ function M.action(selected_option)
       for entry, variables in pairs(config) do
         if entry == "executables" then goto continue end
         entry_point = utils.os_path(variables.entry_point)
-        output = utils.os_path(variables.output)
+        output = utils.os_path(variables.output, false, true)
         output_dir = utils.os_path(output:match("^(.-[/\\])[^/\\]*$"))
         arguments = variables.arguments or arguments -- optional
         task = { name = "- Build program → \"" .. entry_point .. "\"",
-          cmd = "rm -f \"" .. output ..  "\" || true" ..                                        -- clean
-                " && mkdir -p \"" .. output_dir .. "\"" ..                                      -- mkdir
+          cmd = rm .. output .. ignore_err ..                                           -- clean
+                " && " .. mkdir .. output_dir .. ignore_err ..                          -- mkdir
                 " && rustc \"" .. entry_point .. "\" -o \"" .. output .. "\" " .. arguments ..  -- compile
                 " && echo \"" .. entry_point .. "\"" ..                                         -- echo
                 " && echo \"" .. final_message .. "\"",
@@ -97,7 +99,7 @@ function M.action(selected_option)
       local solution_executables = config["executables"]
       if solution_executables then
         for entry, executable in pairs(solution_executables) do
-          executable = utils.os_path(executable, true)
+          executable = utils.os_path(executable, true, true)
           task = { name = "- Run program → " .. executable,
             cmd = executable ..                                                         -- run
                   " && echo " .. executable ..                                          -- echo
@@ -121,14 +123,14 @@ function M.action(selected_option)
       entry_points = utils.find_files(vim.fn.getcwd(), "main.rs")
 
       for _, entry_point in ipairs(entry_points) do
-        entry_point = utils.os_path(entry_point)
-        output_dir = utils.os_path(entry_point:match("^(.-[/\\])[^/\\]*$") .. "bin")           -- entry_point/bin
-        output = utils.os_path(output_dir .. "/program")                                       -- entry_point/bin/program
-        task = { name = "- Build program → \"" .. entry_point .. "\"",
-          cmd = "rm -f \"" .. output ..  "\" || true" ..                                       -- clean
-                " && mkdir -p \"" .. output_dir .. "\"" ..                                     -- mkdir
-                " && rustc \"" .. entry_point .. "\" -o \"" .. output .. "\" " .. arguments .. -- compile
-                " && echo \"" .. entry_point .. "\"" ..                                        -- echo
+        entry_point = utils.os_path(entry_point, true)
+        output_dir = utils.os_path(entry_point:match("^(.-[/\\])[^/\\]*$") .. "bin", true)     -- entry_point/bin
+        output = utils.os_path(output_dir .. "/program", true, true)                          -- entry_point/bin/program
+        task = { name = "- Build program → " .. entry_point,
+          cmd = rm .. output .. ignore_err ..                                          -- clean
+                " && " .. mkdir .. output_dir .. ignore_err ..                         -- mkdir
+                " && rustc " .. entry_point .. " -o " .. output .. " " .. arguments .. -- compile
+                " && echo " .. entry_point ..                                          -- echo
                 " && echo \"" .. final_message .. "\"",
           components = { "default_extended" }
         }

--- a/lua/compiler/utils.lua
+++ b/lua/compiler/utils.lua
@@ -18,7 +18,7 @@ function M.find_files(start_dir, file_name, surround)
   -- Create the find command with appropriate flags for recursive searching
   local find_command
   if string.sub(package.config, 1, 1) == "\\" then -- Windows
-    find_command = string.format('powershell.exe -Command "Get-ChildItem -Path \\"%s\\" -Recurse -Filter \\"%s\\" -File -Exclude \\".git\\" -ErrorAction SilentlyContinue"', start_dir, file_name)
+    find_command = string.format('powershell.exe -Command "Get-ChildItem -Path \\"%s\\" -Recurse -Filter \\"%s\\" -File -Exclude \\".git\\" -ErrorAction SilentlyContinue | Select-Object -ExpandProperty FullName"', start_dir, file_name, start_dir)
   else -- UNIX-like systems
     find_command = string.format('find "%s" -type d -name ".git" -prune -o -type f -name "%s" -print 2>/dev/null', start_dir, file_name)
   end
@@ -157,6 +157,12 @@ function M.os_path(path, surround)
 
   local separator = string.sub(package.config, 1, 1)
 
+  if exe and string.sub(package.config, 1, 1) == "\\" then -- Windows
+    if path:sub(-4) ~= ".exe" then
+      path = path .. ".exe"
+    end
+  end
+
   if surround then
       path = '"' .. path .. '"'
   end
@@ -170,6 +176,29 @@ end
 function M.get_tests_dir(path_to_append)
   local plugin_dir = vim.fn.fnamemodify(debug.getinfo(1, "S").source:sub(2), ":p:h:h:h")
   return M.os_path(plugin_dir .. "/tests/" .. path_to_append)
+end
+
+---Gives you the correct commands for `rm`, `mkdir` and ignoring errors (`|| true` on unix)
+---for the current OS.
+---@usage local rm, mkdir, ignore_error = get_commands()
+---@return string rm_file A command equivalent to `rm -f` for files
+---@return string mkdir A command equivalent to `mkdir -p`
+---@return string ignore_error The construct to ignore an error from the previous command
+function M.get_commands()
+  local commands = {}
+  -- Unix versions
+  commands.rm = "rm -f "
+  commands.mkdir = "mkdir -p "
+  commands.ignore_error = " || true"
+
+  if string.sub(package.config, 1, 1) == "\\" then -- Windows
+    commands.rm = "erase /f /q "
+    -- commands.rm_dir = "rd /s /q "
+    commands.mkdir = "mkdir "
+    commands.ignore_error = " > nul 2> nul & cd." -- rd and mkdir print errors, which we redirect to nul, so they don't show up and with '& cd.' we always get a success return code
+  end
+
+  return commands.rm, commands.mkdir, commands.ignore_error
 end
 
 return M

--- a/lua/compiler/utils.lua
+++ b/lua/compiler/utils.lua
@@ -150,10 +150,14 @@ end
 ---This way the shell will be able to detect spaces in the path.
 ---@param path string A path string.
 ---@param surround boolean|nil If true, surround path by "". False by default.
+---@param exe boolean|nil If true, add .exe to path when on windows
 ---@return string|nil,nil path A path string formatted for the current OS.
-function M.os_path(path, surround)
+function M.os_path(path, surround, exe)
   if path == nil then return nil end
   if surround == nil then surround = false end
+  if exe == nil then exe = false end
+
+  path = path:gsub("\"", "") -- Remove all "
 
   local separator = string.sub(package.config, 1, 1)
 


### PR DESCRIPTION
This PR would make all commands which use `rm -f` and `mkdir -p` windows compatible by adding the `get_commands()` function to `utils` which swaps the unix commands with the cmd commands `erase /s /q` and `mkdir`.
The way to ignore errors is also different and is changed from ` || true` to ` > nul 2> nul & cd.` for cmd. Ignoring errors is also needed for `mkdir` in cmd, since there is no `-p` equivalent. 

I could not test the `asm` changes fully yet, since it uses linux/unix syscalls from what I understand. Building and linking works, but the "Run program" does not succeed and exits with a large negative exit code.

**Languages which had changes:**
- asm
- c
- cpp
- cs
- dart
- go
- java
- kotlin
- python
- rust
- swift
- fortran

**Bau which had changes:**
- cmake
- meson

From my testing, everything should still work on Linux with these changes.

Let me know if I need to change something, or if this PR might go in the wrong direction / uses an undesired approach.