### PR TITLE
set all/clean as default target.

### DIFF
--- a/lua/compiler/utils-bau.lua
+++ b/lua/compiler/utils-bau.lua
@@ -79,6 +79,17 @@ local function get_cmake_opts(path)
         { text = "CMake " .. target, value = target, bau = "cmake" }
       )
     end
+
+    table.insert(
+        options,
+        { text = "CMake " .. "all", value = "all", bau = "cmake" }
+    )
+
+    table.insert(
+        options,
+        { text = "CMake " .. "clean", value = "clean", bau = "cmake" }
+    )
+
   end
 
   return options


### PR DESCRIPTION
In cmake project, the target will only be displayed when add_executable/add_custom_target is detected. 
However, cmake generates the all/clean target by default.