### PR TITLE
feat: native nvim `vim.ui.select` support

### DIFF
--- a/lua/compiler/init.lua
+++ b/lua/compiler/init.lua
@@ -8,7 +8,7 @@ local M = {}
 
 M.setup = function(opts)
   cmd("CompilerOpen", function()
-    require("compiler.telescope").show()
+    require("compiler.picker").show()
   end, { desc = "Open the compiler" })
 
   cmd("CompilerToggleResults", function()

--- a/lua/compiler/picker-util.lua
+++ b/lua/compiler/picker-util.lua
@@ -1,0 +1,131 @@
+--- ### Shared utilities for compiler.nvim pickers
+
+local M = {}
+
+--- Validates that the current working directory is not the home directory
+--- @return boolean true if valid, false if invalid (also shows notification)
+function M.validate_working_directory()
+  if vim.loop.os_homedir() == vim.loop.cwd() then
+    vim.notify(
+      "You must :cd your project dir first.\nHome is not allowed as working dir.",
+      vim.log.levels.WARN,
+      {
+        title = "Compiler.nvim",
+      }
+    )
+    return false
+  end
+  return true
+end
+
+--- Prepares compiler options by gathering language and BAU options
+--- @return table { language, options, filetype }
+function M.prepare_compiler_options()
+  local utils = require("compiler.utils")
+  local utils_bau = require("compiler.utils-bau")
+
+  local buffer = vim.api.nvim_get_current_buf()
+  local filetype = vim.api.nvim_get_option_value("filetype", { buf = buffer })
+
+  -- Programatically require the backend for the current language.
+  local language = utils.require_language(filetype)
+
+  -- On unsupported languages, default to make.
+  if not language then language = utils.require_language("make") or {} end
+
+  -- Also show options discovered on Makefile, Cmake... and other bau.
+  if not language.bau_added then
+    language.bau_added = true
+    local bau_opts = utils_bau.get_bau_opts()
+
+    -- Insert a separator for every bau.
+    local last_bau_value = nil
+    for _, item in ipairs(bau_opts) do
+      if last_bau_value ~= item.bau then
+        table.insert(language.options, { text = "", value = "separator" })
+        last_bau_value = item.bau
+      end
+      table.insert(language.options, item)
+    end
+  end
+
+  -- Add numbers in front of the options to display.
+  local index_counter = 0
+  for _, option in ipairs(language.options) do
+    if option.value ~= "separator" then
+      index_counter = index_counter + 1
+      option.text = index_counter .. " - " .. option.text
+    end
+  end
+
+  return {
+    language = language,
+    options = language.options,
+    filetype = filetype,
+  }
+end
+
+--- Executes the selected compiler option
+--- @param selected_value string The value of the selected option
+--- @param selected_text string The display text of the selected option
+--- @param language_options table The full options table
+--- @param filetype string The current filetype
+function M.execute_selection(
+  selected_value,
+  selected_text,
+  language_options,
+  language,
+  filetype
+)
+  if selected_value == "" or selected_value == "separator" then return end
+
+  local utils_bau = require("compiler.utils-bau")
+
+  -- Do the selected option belong to a build automation utility?
+  local bau = nil
+  for _, value in ipairs(language_options) do
+    if value.text == selected_text or value.value == selected_value then
+      bau = value.bau
+      break
+    end
+  end
+
+  if bau then -- call the bau backend.
+    bau = utils_bau.require_bau(bau)
+    if bau then bau.action(selected_value) end
+    -- then
+    -- clean redo (language)
+    _G.compiler_redo_selection = nil
+    -- save redo (bau)
+    _G.compiler_redo_bau_selection = selected_value
+    _G.compiler_redo_bau = bau
+  else -- call the language backend.
+    language.action(selected_value)
+    -- then
+    -- save redo (language)
+    _G.compiler_redo_selection = selected_value
+    _G.compiler_redo_filetype = filetype
+    -- clean redo (bau)
+    _G.compiler_redo_bau_selection = nil
+    _G.compiler_redo_bau = nil
+  end
+end
+
+--- Creates items and mapping for vim.ui.select (filters out separators)
+--- @param language_options table The full options table
+--- @return table { items, item_map }
+function M.create_select_items(language_options)
+  local items = {}
+  local item_map = {}
+
+  for _, option in ipairs(language_options) do
+    if option.value ~= "separator" then
+      table.insert(items, option.text)
+      item_map[option.text] = { value = option.value, bau = option.bau }
+    end
+  end
+
+  return { items = items, item_map = item_map }
+end
+
+return M

--- a/lua/compiler/picker.lua
+++ b/lua/compiler/picker.lua
@@ -10,99 +10,37 @@ function M.show()
     require("compiler.telescope").show()
   else
     -- Fallback to vim.ui.select implementation
-    -- If working directory is home, don't open picker.
-    if vim.loop.os_homedir() == vim.loop.cwd() then
-      vim.notify(
-        "You must :cd your project dir first.\nHome is not allowed as working dir.",
-        vim.log.levels.WARN,
-        {
-          title = "Compiler.nvim",
-        }
-      )
-      return
-    end
+    local picker_util = require("compiler.picker-util")
 
-    local utils = require("compiler.utils")
-    local utils_bau = require("compiler.utils-bau")
+    -- Validate working directory
+    if not picker_util.validate_working_directory() then return end
 
-    local buffer = vim.api.nvim_get_current_buf()
-    local filetype =
-      vim.api.nvim_get_option_value("filetype", { buf = buffer })
+    -- Prepare compiler options
+    local compiler_data = picker_util.prepare_compiler_options()
+    local language = compiler_data.language
+    local options = compiler_data.options
+    local filetype = compiler_data.filetype
 
-    -- POPULATE
-    -- ========================================================================
+    -- Create items for vim.ui.select
+    local select_data = picker_util.create_select_items(options)
+    local items = select_data.items
+    local item_map = select_data.item_map
 
-    -- Programatically require the backend for the current language.
-    local language = utils.require_language(filetype)
-
-    -- On unsupported languages, default to make.
-    if not language then language = utils.require_language("make") or {} end
-
-    -- Also show options discovered on Makefile, Cmake... and other bau.
-    if not language.bau_added then
-      language.bau_added = true
-      local bau_opts = utils_bau.get_bau_opts()
-
-      -- Insert a separator for every bau.
-      local last_bau_value = nil
-      for _, item in ipairs(bau_opts) do
-        if last_bau_value ~= item.bau then
-          table.insert(language.options, { text = "", value = "separator" })
-          last_bau_value = item.bau
-        end
-        table.insert(language.options, item)
-      end
-    end
-
-    -- Add numbers in front of the options to display.
-    local index_counter = 0
-    for _, option in ipairs(language.options) do
-      if option.value ~= "separator" then
-        index_counter = index_counter + 1
-        option.text = index_counter .. " - " .. option.text
-      end
-    end
-
-    -- Create items for vim.ui.select (filter out separators)
-    local items = {}
-    local item_map = {}
-    for _, option in ipairs(language.options) do
-      if option.value ~= "separator" then
-        table.insert(items, option.text)
-        item_map[option.text] = { value = option.value, bau = option.bau }
-      end
-    end
-
-    -- SHOW VIM.UI.SELECT
-    -- ========================================================================
+    -- Show vim.ui.select
     vim.ui.select(items, {
       prompt = "Compiler: ",
     }, function(choice)
       if not choice then return end
       local selected = item_map[choice]
-      if not selected or selected.value == "" then return end
+      if not selected then return end
 
-      -- Do the selected option belong to a build automation utility?
-      local bau = selected.bau
-      if bau then -- call the bau backend.
-        bau = utils_bau.require_bau(bau)
-        if bau then bau.action(selected.value) end
-        -- then
-        -- clean redo (language)
-        _G.compiler_redo_selection = nil
-        -- save redo (bau)
-        _G.compiler_redo_bau_selection = selected.value
-        _G.compiler_redo_bau = bau
-      else -- call the language backend.
-        language.action(selected.value)
-        -- then
-        -- save redo (language)
-        _G.compiler_redo_selection = selected.value
-        _G.compiler_redo_filetype = filetype
-        -- clean redo (bau)
-        _G.compiler_redo_bau_selection = nil
-        _G.compiler_redo_bau = nil
-      end
+      picker_util.execute_selection(
+        selected.value,
+        choice,
+        options,
+        language,
+        filetype
+      )
     end)
   end
 end

--- a/lua/compiler/picker.lua
+++ b/lua/compiler/picker.lua
@@ -1,0 +1,110 @@
+--- ### Picker frontend for compiler.nvim
+-- Automatically detects and uses telescope.nvim or falls back to vim.ui.select
+
+local M = {}
+
+function M.show()
+  local telescope_ok = pcall(require, "telescope")
+
+  if telescope_ok then
+    require("compiler.telescope").show()
+  else
+    -- Fallback to vim.ui.select implementation
+    -- If working directory is home, don't open picker.
+    if vim.loop.os_homedir() == vim.loop.cwd() then
+      vim.notify(
+        "You must :cd your project dir first.\nHome is not allowed as working dir.",
+        vim.log.levels.WARN,
+        {
+          title = "Compiler.nvim",
+        }
+      )
+      return
+    end
+
+    local utils = require("compiler.utils")
+    local utils_bau = require("compiler.utils-bau")
+
+    local buffer = vim.api.nvim_get_current_buf()
+    local filetype =
+      vim.api.nvim_get_option_value("filetype", { buf = buffer })
+
+    -- POPULATE
+    -- ========================================================================
+
+    -- Programatically require the backend for the current language.
+    local language = utils.require_language(filetype)
+
+    -- On unsupported languages, default to make.
+    if not language then language = utils.require_language("make") or {} end
+
+    -- Also show options discovered on Makefile, Cmake... and other bau.
+    if not language.bau_added then
+      language.bau_added = true
+      local bau_opts = utils_bau.get_bau_opts()
+
+      -- Insert a separator for every bau.
+      local last_bau_value = nil
+      for _, item in ipairs(bau_opts) do
+        if last_bau_value ~= item.bau then
+          table.insert(language.options, { text = "", value = "separator" })
+          last_bau_value = item.bau
+        end
+        table.insert(language.options, item)
+      end
+    end
+
+    -- Add numbers in front of the options to display.
+    local index_counter = 0
+    for _, option in ipairs(language.options) do
+      if option.value ~= "separator" then
+        index_counter = index_counter + 1
+        option.text = index_counter .. " - " .. option.text
+      end
+    end
+
+    -- Create items for vim.ui.select (filter out separators)
+    local items = {}
+    local item_map = {}
+    for _, option in ipairs(language.options) do
+      if option.value ~= "separator" then
+        table.insert(items, option.text)
+        item_map[option.text] = { value = option.value, bau = option.bau }
+      end
+    end
+
+    -- SHOW VIM.UI.SELECT
+    -- ========================================================================
+    vim.ui.select(items, {
+      prompt = "Compiler: ",
+    }, function(choice)
+      if not choice then return end
+      local selected = item_map[choice]
+      if not selected or selected.value == "" then return end
+
+      -- Do the selected option belong to a build automation utility?
+      local bau = selected.bau
+      if bau then -- call the bau backend.
+        bau = utils_bau.require_bau(bau)
+        if bau then bau.action(selected.value) end
+        -- then
+        -- clean redo (language)
+        _G.compiler_redo_selection = nil
+        -- save redo (bau)
+        _G.compiler_redo_bau_selection = selected.value
+        _G.compiler_redo_bau = bau
+      else -- call the language backend.
+        language.action(selected.value)
+        -- then
+        -- save redo (language)
+        _G.compiler_redo_selection = selected.value
+        _G.compiler_redo_filetype = filetype
+        -- clean redo (bau)
+        _G.compiler_redo_bau_selection = nil
+        _G.compiler_redo_bau = nil
+      end
+    end)
+  end
+end
+
+return M

--- a/lua/compiler/telescope.lua
+++ b/lua/compiler/telescope.lua
@@ -3,61 +3,23 @@
 local M = {}
 
 function M.show()
-  -- If working directory is home, don't open telescope.
-  if vim.loop.os_homedir() == vim.loop.cwd() then
-    vim.notify("You must :cd your project dir first.\nHome is not allowed as working dir.", vim.log.levels.WARN, {
-      title = "Compiler.nvim"
-    })
-    return
-  end
+  local picker_util = require("compiler.picker-util")
+
+  -- Validate working directory
+  if not picker_util.validate_working_directory() then return end
 
   -- Dependencies
   local conf = require("telescope.config").values
-  local actions = require "telescope.actions"
-  local state = require "telescope.actions.state"
-  local pickers = require "telescope.pickers"
-  local finders = require "telescope.finders"
-  local utils = require("compiler.utils")
-  local utils_bau = require("compiler.utils-bau")
+  local actions = require("telescope.actions")
+  local state = require("telescope.actions.state")
+  local pickers = require("telescope.pickers")
+  local finders = require("telescope.finders")
 
-  local buffer = vim.api.nvim_get_current_buf()
-  local filetype = vim.api.nvim_get_option_value("filetype", { buf = buffer })
-
-
-  -- POPULATE
-  -- ========================================================================
-
-  -- Programatically require the backend for the current language.
-  local language = utils.require_language(filetype)
-
-  -- On unsupported languages, default to make.
-  if not language then language = utils.require_language("make") or {} end
-
-  -- Also show options discovered on Makefile, Cmake... and other bau.
-  if not language.bau_added then
-    language.bau_added = true
-    local bau_opts = utils_bau.get_bau_opts()
-
-    -- Insert a separator on telescope for every bau.
-    local last_bau_value = nil
-    for _, item in ipairs(bau_opts) do
-      if last_bau_value ~= item.bau then
-        table.insert(language.options, { text = "", value = "separator" })
-        last_bau_value = item.bau
-      end
-      table.insert(language.options, item)
-    end
-  end
-
-  -- Add numbers in front of the options to display.
-  local index_counter = 0
-  for _, option in ipairs(language.options) do
-    if option.value ~= "separator" then
-      index_counter = index_counter + 1
-      option.text = index_counter .. " - " .. option.text
-    end
-  end
-
+  -- Prepare compiler options
+  local compiler_data = picker_util.prepare_compiler_options()
+  local language = compiler_data.language
+  local language_options = compiler_data.options
+  local filetype = compiler_data.filetype
 
   -- RUN ACTION ON SELECTED
   -- ========================================================================
@@ -66,40 +28,17 @@ function M.show()
   local function on_option_selected(prompt_bufnr)
     actions.close(prompt_bufnr) -- Close Telescope on selection
     local selection = state.get_selected_entry()
-    if selection.value == "" then return end -- Ignore separators
 
     if selection then
-      -- Do the selected option belong to a build automation utility?
-      local bau = nil
-      for _, value in ipairs(language.options) do
-        if value.text == selection.display then
-          bau = value.bau
-        end
-      end
-
-      if bau then -- call the bau backend.
-        bau = utils_bau.require_bau(bau)
-        if bau then bau.action(selection.value) end
-        -- then
-        -- clean redo (language)
-        _G.compiler_redo_selection = nil
-        -- save redo (bau)
-        _G.compiler_redo_bau_selection = selection.value
-        _G.compiler_redo_bau = bau
-      else -- call the language backend.
-        language.action(selection.value)
-        -- then
-        -- save redo (language)
-        _G.compiler_redo_selection = selection.value
-        _G.compiler_redo_filetype = filetype
-        -- clean redo (bau)
-        _G.compiler_redo_bau_selection = nil
-        _G.compiler_redo_bau = nil
-      end
-
+      picker_util.execute_selection(
+        selection.value,
+        selection.display,
+        language_options,
+        language,
+        filetype
+      )
     end
   end
-
 
   -- SHOW TELESCOPE
   -- ========================================================================
@@ -108,8 +47,8 @@ function M.show()
       .new({}, {
         prompt_title = "Compiler",
         results_title = "Options",
-        finder = finders.new_table {
-          results = language.options,
+        finder = finders.new_table({
+          results = language_options,
           entry_maker = function(entry)
             return {
               display = entry.text,
@@ -117,7 +56,7 @@ function M.show()
               ordinal = entry.text,
             }
           end,
-        },
+        }),
         sorter = conf.generic_sorter(),
         attach_mappings = function(_, map)
           map(


### PR DESCRIPTION
Closes #72 

## Description
This adds support for the native nvim api `vim.ui.select` as a fall back if you don't have telescope installed. this should cover the majority of the pickers such as `snacks`, `fzf` and `mini`.

I created the picker-util since there was a lot of code duplication between telescope.lua and picker.lua, if you're not happy with this change I can revert it to my first commit which just added the basic fall back

## Note
I've not done extensive testing with these changes, I was using a lazynvim repro.lua and enable/disable telescope/snacks and building a zig project and it seemed to be working fine

```lua
-- save as repro.lua
-- run with nvim -u repro.lua
-- DO NOT change the paths
local root = vim.fn.fnamemodify("./.repro", ":p")

-- set stdpaths to use .repro
for _, name in ipairs({ "config", "data", "state", "runtime", "cache" }) do
  vim.env[("XDG_%s_HOME"):format(name:upper())] = root .. "/" .. name
end

-- bootstrap lazy
local lazypath = root .. "/plugins/lazy.nvim"
if not vim.loop.fs_stat(lazypath) then
  -- stylua: ignore
  vim.fn.system({ "git", "clone", "--filter=blob:none", "https://github.com/folke/lazy.nvim.git", "--branch=stable",
    lazypath })
end
vim.opt.rtp:prepend(vim.env.LAZY or lazypath)

-- install plugins
local plugins = {
  { "AstroNvim/AstroNvim",             import = "astronvim.plugins" },
  { "AstroNvim/astrocommunity" },
  { import = "astrocommunity.pack.zig" },
  -- { import = "astrocommunity.fuzzy-finder.telescope-nvim" }, -- Enable this to swap to telescope instead of snames

  -- Add your local compiler.nvim for testing
  {
    dir = "/home/nciechanowski/Projects/compiler.nvim",
    name = "compiler.nvim",
    dependencies = { "stevearc/overseer.nvim" },
    config = function()
      require("compiler").setup()
    end,
  },

  -- add any other plugins/customizations here
}
require("lazy").setup(plugins, {
  root = root .. "/plugins",
})

-- add anything else here (autocommands, vim.filetype, etc.)

```